### PR TITLE
fix: Update snap build to use new rust nightly

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ parts:
     source-depth: 1
     source-branch: master
     plugin: x-rust
-    rust-revision: nightly-2018-07-22
+    rust-revision: nightly-2019-08-09
     override-build: |
       snapcraftctl build
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/share/device-checkout


### PR DESCRIPTION
Missed another of the nightly versions so the snapcraft build was still failing.

Change-Id: Idab2e39a2e47ace5a2eb4225a50ae7ed6ef00903