### PR TITLE
Add reservations API and device pools

### DIFF
--- a/doc/device-checkout-openapi.yaml
+++ b/doc/device-checkout-openapi.yaml
@@ -58,9 +58,13 @@ paths:
           format: int32
       responses:
         '204':
-          description: reservation deleted
+          description: Reservation deleted
+        '400':
+          description: Reservation has already been ended
+        '404':
+          description: Cannot find reservation with given ID
         default:
-          description: unexpected error
+          description: Unexpected error
           content:
             application/json:
               schema:

--- a/doc/device-checkout-openapi.yaml
+++ b/doc/device-checkout-openapi.yaml
@@ -1,0 +1,116 @@
+openapi: "3.0.2"
+info:
+  title: Device Checkout API documentation
+  version: 0.1.0
+paths:
+  /api/reservations:
+    post:
+      description: Creates a reservation for a device that matches the parameters
+      summary: Reserve device by params
+      operationId: reserveDeviceByParams
+      requestBody:
+        description: Reservation to book
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewReservation'
+            example:
+                owner: Alice
+                comment: Using to demonstrate API usage
+                device:
+                  sku: ED5000
+      responses:
+        '200':
+          description: reservation response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reservation'
+              example:
+                id: 1
+                owner: Alice
+                comment: Using to demonstrate API usage
+                device:
+                  id: 1
+                  name: test-device-1
+                  url: http://test-device.example-org
+                  sku: ED5000
+
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/reservations/{id}:
+    delete:
+      description: End a reservation of a device
+      summary: Return device
+      operationId: deleteReservation
+      parameters:
+      - name: id
+        in: path
+        description: ID of reservation to end
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '204':
+          description: reservation deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Reservation:
+      allOf:
+        - $ref: '#/components/schemas/NewReservation'
+        - type: object
+      required:
+        - id
+        - device
+        - owner
+      properties:
+        id:
+          type: integer
+          format: int32
+    NewReservation:
+      type: object
+      required:
+        - owner
+      properties:
+        device:
+          type: object
+          $ref: '#/components/schemas/Device'
+        owner:
+          type: string
+        comment:
+          type: string
+    Device:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+        url:
+          type: string
+        sku:
+          type: string
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/migrations/2019-08-22-053425_add-pools/down.sql
+++ b/migrations/2019-08-22-053425_add-pools/down.sql
@@ -1,0 +1,35 @@
+-- This file should undo anything in `up.sql`
+create temporary table devices_backup(id, device_name, device_url, device_owner, comments, reservation_status, created_at, updated_at);
+
+insert into devices_backup select id, device_name, device_url, device_owner, comments, reservation_status, created_at, updated_at from devices;
+
+drop table devices;
+
+--copied from the previous migration
+create table devices (
+	id integer primary key not null,
+	device_name text unique not null,
+	device_url text,
+	device_owner text,
+	comments text,
+	reservation_status text not null default 'available',
+	created_at timestamp default current_timestamp not null,
+	updated_at timestamp default current_timestamp not null,
+	--device_name not empty
+	check (device_name <> '')
+	--reservation_status is an enum
+	check(reservation_status in ('available', 'reserved'))
+	--if we're reserved, then we need a not empty device_owner
+	check (reservation_status <> "reserved" or (device_owner is not null and device_owner <> ''))
+);
+
+insert into devices select id, device_name, device_url, device_owner, comments, reservation_status, created_at, updated_at from devices_backup;
+
+drop table devices_backup;
+
+create trigger devices after update on devices
+begin
+	update devices set updated_at = current_timestamp where id = NEW.id;
+end;
+
+drop table pools;

--- a/migrations/2019-08-22-053425_add-pools/up.sql
+++ b/migrations/2019-08-22-053425_add-pools/up.sql
@@ -1,0 +1,52 @@
+-- Your SQL goes here
+
+create table pools (
+	id integer primary key not null,
+	pool_name text not null,
+	created_at timestamp default current_timestamp not null,
+	updated_at timestamp default current_timestamp not null,
+	check (pool_name <> '')
+);
+
+create trigger pools after update on pools
+begin
+	update pools set updated_at = current_timestamp where id = NEW.id;
+end;
+
+insert into pools (pool_name) values ('Default Pool');
+
+create temporary table devices_backup(id, device_name, device_url, device_owner, comments, reservation_status, created_at, updated_at);
+
+insert into devices_backup select id, device_name, device_url, device_owner, comments, reservation_status, created_at, updated_at from devices;
+
+drop table devices;
+
+create table devices (
+	id integer primary key not null,
+	device_name text unique not null,
+	pool_id integer not null references pools(id),
+	device_url text,
+	device_owner text,
+	comments text,
+	reservation_status text not null default 'available',
+	created_at timestamp default current_timestamp not null,
+	updated_at timestamp default current_timestamp not null,
+	--device_name not empty
+	check (device_name <> '')
+	--reservation_status is an enum
+	check(reservation_status in ('available', 'reserved'))
+	--if we're reserved, then we need a not empty device_owner
+	check (reservation_status <> "reserved" or (device_owner is not null and device_owner <> ''))
+);
+
+insert into devices (id, device_name, device_url, device_owner, comments, reservation_status, created_at, updated_at, pool_id)
+select devices_backup.id, device_name, device_url, device_owner, comments, reservation_status, devices_backup.created_at, devices_backup.updated_at, pools.id
+from devices_backup, pools
+where pools.pool_name = 'Default Pool' ;
+
+drop table devices_backup;
+
+create trigger devices after update on devices
+begin
+	update devices set updated_at = current_timestamp where id = NEW.id;
+end;

--- a/src/database.rs
+++ b/src/database.rs
@@ -49,6 +49,20 @@ pub fn get_device(
         .next())
 }
 
+///Lookup a single device by id
+pub fn get_device_by_id(
+    _config: &utils::types::Settings,
+    database: &DbConn,
+    requested_id: i32,
+) -> Result<Option<models::Device>, failure::Error> {
+    Ok(devices
+        .filter(id.eq(requested_id))
+        .load::<models::Device>(database)
+        .with_context(|_| "Error loading devices".to_string())?
+        .into_iter()
+        .next())
+}
+
 ///Updates a device, designed for the common case on the main http form
 pub fn update_device(
     _config: &utils::types::Settings,

--- a/src/database.rs
+++ b/src/database.rs
@@ -8,6 +8,7 @@ use self::diesel::prelude::*;
 use failure::ResultExt;
 use schema::devices;
 use schema::devices::dsl::*;
+use schema::pools::dsl::pools;
 
 pub type DbConn = diesel::sqlite::SqliteConnection;
 
@@ -111,6 +112,7 @@ pub fn edit_device(
         .set((
             device_name.eq(&device_edit.device_name),
             device_url.eq(&device_edit.device_url),
+            pool_id.eq(&device_edit.pool_id),
         ))
         .execute(database)?)
 }
@@ -133,4 +135,14 @@ pub fn insert_device(
     Ok(diesel::insert_into(devices::table)
         .values(device_insert)
         .execute(database)?)
+}
+
+///Get all the pools
+pub fn get_pools(
+    _config: &utils::types::Settings,
+    database: &DbConn,
+) -> Result<Vec<models::Pool>, failure::Error> {
+    Ok(pools
+        .load::<models::Pool>(database)
+        .with_context(|_| "Error loading pools".to_string())?)
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -63,6 +63,24 @@ pub fn get_device_by_id(
         .next())
 }
 
+///Lookup a single available device from a pool
+pub fn get_available_device_from_pool(
+    _config: &utils::types::Settings,
+    database: &DbConn,
+    requested_pool_id: &i32,
+) -> Result<Option<models::Device>, failure::Error> {
+    Ok(devices
+        .filter(
+            pool_id
+                .eq(requested_pool_id)
+                .and(reservation_status.eq(models::ReservationStatus::Available)),
+        )
+        .load::<models::Device>(database)
+        .with_context(|_| "Error loading devices".to_string())?
+        .into_iter()
+        .next())
+}
+
 ///Updates a device, designed for the common case on the main http form
 pub fn update_device(
     _config: &utils::types::Settings,

--- a/src/models.rs
+++ b/src/models.rs
@@ -206,6 +206,37 @@ pub struct DeviceInsert {
     pub device_url: String,
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Queryable, Serialize, Deserialize)]
+pub struct Reservation {
+    pub id: i32,
+    pub device_owner: String,
+    pub comments: Option<String>,
+    pub device: Device,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+pub struct ReservationRequest {
+    pub device_owner: Option<String>,
+    pub comments: Option<String>,
+    pub device: ReservationRequestDevice,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+pub struct ReservationRequestDevice {
+    pub id: Option<i32>,
+    pub device_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub device_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub device_owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub comments: Option<String>,
+    pub pool_id: i32,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -166,6 +166,7 @@ pub struct DeviceEdit {
     pub device_name: String,
     #[validate(url(message = "URL was invalid"))]
     pub device_url: String,
+    pub pool_id: i32,
 }
 
 #[cfg_attr(
@@ -204,6 +205,7 @@ pub struct DeviceInsert {
     pub device_name: String,
     #[validate(url(message = "URL was invalid"))]
     pub device_url: String,
+    pub pool_id: i32,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Queryable, Serialize, Deserialize)]
@@ -261,6 +263,7 @@ mod test {
         let mut device = DeviceInsert {
             device_name: "".into(),
             device_url: "".into(),
+            pool_id: 0,
         };
         assert!(device.validate().is_err());
         device.device_name = "test".into();
@@ -276,6 +279,7 @@ mod test {
             id: 0,
             device_name: "".into(),
             device_url: "".into(),
+            pool_id: 0,
         };
         assert!(device.validate().is_err());
         device.device_name = "test".into();

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use chrono;
 use rocket;
-use schema::devices;
+use schema::*;
 use std;
 use validator::{Validate, ValidationError};
 
@@ -43,7 +43,21 @@ impl<'v> FromFormValue<'v> for ReservationStatus {
 }
 
 //deliberately not making this Copy
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Queryable, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    Identifiable,
+    Queryable,
+    Associations,
+    Serialize,
+    Deserialize,
+)]
+#[belongs_to(Pool)]
 pub struct Device {
     pub id: i32,
     pub device_name: String,
@@ -57,6 +71,28 @@ pub struct Device {
     #[serde(default)]
     pub comments: Option<String>,
     pub reservation_status: ReservationStatus,
+    pub created_at: chrono::NaiveDateTime,
+    pub updated_at: chrono::NaiveDateTime,
+    pub pool_id: i32,
+}
+
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    Identifiable,
+    Queryable,
+    Insertable,
+    Serialize,
+    Deserialize,
+)]
+pub struct Pool {
+    pub id: i32,
+    pub pool_name: String,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
 }
@@ -74,7 +110,6 @@ pub struct Device {
     Default,
     Clone,
     Hash,
-    Queryable,
     Serialize,
     Deserialize,
     FromForm,
@@ -120,7 +155,6 @@ fn validate_device_checkout(device: &DeviceUpdate) -> Result<(), ValidationError
     Default,
     Clone,
     Hash,
-    Queryable,
     Serialize,
     Deserialize,
     FromForm,
@@ -158,7 +192,6 @@ pub struct DeviceDelete {
     Default,
     Clone,
     Hash,
-    Queryable,
     Serialize,
     Deserialize,
     FromForm,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -29,6 +29,7 @@ pub fn api_routes() -> Vec<rocket::Route> {
     routes![
         self::api_get_device,
         self::api_get_devices,
+        self::api_post_reservations,
         self::api_delete_reservation,
     ]
 }
@@ -74,6 +75,47 @@ pub fn api_get_devices(
     trace!("api_get_devices()");
     let devices = database::get_devices(&*config, &*database)?;
     Ok(rocket_contrib::json::Json(devices))
+}
+
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+#[post("/reservations", format = "application/json", data = "<reservation>")]
+pub fn api_post_reservations(
+    config: rocket::State<utils::types::Settings>,
+    database: pool::DbConn,
+    reservation: rocket_contrib::json::Json<models::ReservationRequest>,
+) -> Result<rocket_contrib::json::Json<models::Reservation>, rocket::http::Status> {
+    trace!("api_post_reservations");
+    // Find an available device from the pool specified
+    let available_device =
+        database::get_available_device_from_pool(&*config, &*database, &reservation.device.pool_id)
+            .map_err(|_| rocket::http::Status::InternalServerError)
+            .and_then(|devices| devices.ok_or_else(|| rocket::http::Status::NotFound))?;
+    // Set the device as reserved
+    let update_reserved_device = models::DeviceUpdate {
+        id: available_device.id,
+        device_owner: reservation.device_owner.clone(),
+        comments: reservation.comments.clone(),
+        reservation_status: models::ReservationStatus::Reserved,
+    };
+    let updated_device = match database::update_device(
+        &*config,
+        &*database,
+        &update_reserved_device,
+        models::ReservationStatus::Available,
+    ) {
+        Ok(0) | Err(_) => Err(rocket::http::Status::InternalServerError),
+        _ => database::get_device(&*config, &*database, &available_device.device_name)
+            .map_err(|_| rocket::http::Status::InternalServerError)
+            .and_then(|devices| devices.ok_or_else(|| rocket::http::Status::NotFound)),
+    }?;
+    // Return a reservation response with the reserved device
+    let reservation_response = models::Reservation {
+        id: updated_device.id.clone(),
+        device: updated_device,
+        device_owner: reservation.device_owner.clone().unwrap(),
+        comments: reservation.comments.clone(),
+    };
+    Ok(rocket_contrib::json::Json(reservation_response))
 }
 
 #[delete("/reservations/<id>")]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -160,6 +160,7 @@ struct PerDeviceContext {
 #[derive(Serialize, Default)]
 struct DevicesContext<'a> {
     devices: Vec<PerDeviceContext>,
+    pools: Vec<models::Pool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error_message: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -205,8 +206,11 @@ fn gen_device_context<'a>(
         .map(format_device)
         .collect();
 
+    let pools: Vec<_> = database::get_pools(config, database)?;
+
     Ok(DevicesContext {
         devices,
+        pools,
         error_message,
         success_message,
     })

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -8,5 +8,19 @@ table! {
         reservation_status -> ::models::ReservationStatusMapping,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        pool_id -> Integer,
     }
 }
+
+table! {
+    pools (id) {
+        id -> Integer,
+        pool_name -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+joinable!(devices -> pools (pool_id));
+
+allow_tables_to_appear_in_same_query!(devices, pools,);

--- a/templates/devices.html.hbs
+++ b/templates/devices.html.hbs
@@ -27,27 +27,35 @@
 					<tr>
 						<th>Device name</th>
 						<th>URL</th>
+						<th>Device Pool</th>
 						<th>Owner</th>
 						<th>Comments</th>
 						<th>Last Changed</th>
 						<th></th>
 					</tr>
 				</thead>
-				{{#each devices}}
+				{{#each devices as |device|}}
 				<tr>
-					<td>{{this.device.device_name}}</td>
-					<td><a href="{{this.device.device_url}}">{{this.device.device_url}}</a></td>
-					<td><input type="text" name="device_owner" class="form-control" value="{{this.device.device_owner}}" form="reserve-{{this.device.id}}"></td>
-					<td><input type="text" name="comments" class="form-control" value="{{this.device.comments}}" form="reserve-{{this.device.id}}"></td>
-					<td>{{this.updated_at_local}}</td>
+					<td>{{device.device.device_name}}</td>
+					<td><a href="{{device.device.device_url}}">{{device.device.device_url}}</a></td>
 					<td>
-						<form id="reserve-{{this.device.id}}" name="reserve-{{this.device.id}}" action="/devices" method="post">
-							<input type="hidden" name="id" value="{{this.device.id}}" class="form-control" form="reserve-{{this.device.id}}">
-							<input type="hidden" name="reservation_status" value="{{this.device.reservation_status}}" class="form-control" form="reserve-{{this.device.id}}">
-							{{#if this.is_reserved}}
-							<input type="submit" class="btn btn-danger" value="RETURN" form="reserve-{{this.device.id}}">
+					{{#each ../pools as |pool|}}
+						{{#if (eq pool.id device.device.pool_id)}}
+							{{pool.pool_name}}
+						{{/if}}
+					{{/each}}
+					</td>
+					<td><input type="text" name="device_owner" class="form-control" value="{{device.device.device_owner}}" form="reserve-{{device.device.id}}"></td>
+					<td><input type="text" name="comments" class="form-control" value="{{device.device.comments}}" form="reserve-{{device.device.id}}"></td>
+					<td>{{device.updated_at_local}}</td>
+					<td>
+						<form id="reserve-{{device.device.id}}" name="reserve-{{device.device.id}}" action="/devices" method="post">
+							<input type="hidden" name="id" value="{{device.device.id}}" class="form-control" form="reserve-{{device.device.id}}">
+							<input type="hidden" name="reservation_status" value="{{device.device.reservation_status}}" class="form-control" form="reserve-{{device.device.id}}">
+							{{#if device.is_reserved}}
+							<input type="submit" class="btn btn-danger" value="RETURN" form="reserve-{{device.device.id}}">
 							{{else}}
-							<input type="submit" class="btn btn-primary" value="CLAIM" form="reserve-{{this.device.id}}">
+							<input type="submit" class="btn btn-primary" value="CLAIM" form="reserve-{{device.device.id}}">
 							{{/if}}
 						</form>
 					</td>

--- a/templates/edit_devices.html.hbs
+++ b/templates/edit_devices.html.hbs
@@ -53,28 +53,38 @@ $("#confirm-modal-{{this.device.id}}").click(function(){
 					<tr>
 						<th>Device name</th>
 						<th>URL</th>
+						<th>Device Pool</th>
 						<th></th>
 						<th></th>
 					</tr>
 				</thead>
-				{{#each devices}}
+				{{#each devices as |device|}}
 				<tr>
 					<td>
-						<input type="text" name="device_name" class="form-control" value="{{this.device.device_name}}" form="edit-{{this.device.id}}">
+						<input type="text" name="device_name" class="form-control" value="{{device.device.device_name}}" form="edit-{{device.device.id}}">
 					</td>
 					<td>
-						<input type="text" name="device_url" class="form-control" value="{{this.device.device_url}}" form="edit-{{this.device.id}}">
+						<input type="text" name="device_url" class="form-control" value="{{device.device.device_url}}" form="edit-{{device.device.id}}">
 					</td>
 					<td>
-						<form id="edit-{{this.device.id}}" name="edit-{{this.device.id}}" action="/editDevices" method="post">
-							<input type="hidden" name="id" value="{{this.device.id}}" class="form-control">
+						<select name="pool_id" class="form-control" form="edit-{{device.device.id}}">
+							{{#each ../pools as |pool|}}
+							<option value="{{pool.id}}" {{#if (eq pool.id device.device.pool_id)}}selected{{/if}}>
+								{{pool.pool_name}}
+							</option>
+							{{/each}}
+						</select>
+					</td>
+					<td>
+						<form id="edit-{{device.device.id}}" name="edit-{{device.device.id}}" action="/editDevices" method="post">
+							<input type="hidden" name="id" value="{{device.device.id}}" class="form-control">
 							<input type="submit" class="btn btn-primary" name="save" value="SAVE">
 						</form>
 					</td >
 					<td>
-						<form id="delete-{{this.device.id}}" name="delete-{{this.device.id}}" action="/deleteDevices" method="post">
-							<input type="hidden" name="id" value="{{this.device.id}}" class="form-control">
-							<button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete-{{this.device.id}}">
+						<form id="delete-{{device.device.id}}" name="delete-{{device.device.id}}" action="/deleteDevices" method="post">
+							<input type="hidden" name="id" value="{{device.device.id}}" class="form-control">
+							<button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete-{{device.device.id}}">
 								DELETE
 							</button>
 						</form>
@@ -87,6 +97,13 @@ $("#confirm-modal-{{this.device.id}}").click(function(){
 					</td>
 					<td>
 						<input type="text" name="device_url" class="form-control" value="" form="_internal_new_device">
+					</td>
+					<td>
+						<select name="pool_id" class="form-control" form="_internal_new_device">
+							{{#each pools}}
+							<option value="{{this.id}}">{{this.pool_name}}</option>
+							{{/each}}
+						</select>
 					</td>
 					<td>
 						<form id="_internal_new_device" name="_internal_new_device" action="/addDevices" method="post">

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -272,7 +272,7 @@ fn test_html_edit_devices() {
     let response = client
         .post("/editDevices")
         .header(rocket::http::ContentType(rocket::http::MediaType::Form))
-        .body(r#"id=1&device_name=testunit&device_url=http://testurl&save=SAVE"#)
+        .body(r#"id=1&device_name=testunit&device_url=http://testurl&pool_id=1&save=SAVE"#)
         .dispatch();
 
     let mut response = follow_redirect(&client, &response).unwrap();
@@ -367,7 +367,7 @@ fn test_html_add_devices() {
     let response = client
         .post("/addDevices")
         .header(rocket::http::ContentType(rocket::http::MediaType::Form))
-        .body(r#"device_name=testunit&device_url=http://testurl&add=ADD"#)
+        .body(r#"device_name=testunit&device_url=http://testurl&pool_id=1&add=ADD"#)
         .dispatch();
 
     let mut response = follow_redirect(&client, &response).unwrap();


### PR DESCRIPTION
Commits to add two new features to device-checkout.  An API for managing reservations of devices (making a new reservation and ending a reservation) and associating devices with device pools.